### PR TITLE
fix: Resolve issues with scrolling to item

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -248,12 +248,11 @@ class Autocomplete extends React.Component {
     } = this.state;
 
     const {
-      open,
       onMenuVisibilityChange,
     } = this.props;
 
-    if ((isOpen && !prevState.isOpen) || (open && !prevProps.open))
     this.maybeScrollItemIntoView()
+
     if (prevState.isOpen !== isOpen) {
       onMenuVisibilityChange(isOpen)
     }

--- a/lib/__tests__/Autocomplete-test.js
+++ b/lib/__tests__/Autocomplete-test.js
@@ -4,8 +4,14 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import { render, fireEvent } from '@testing-library/react'
+jest.mock('dom-scroll-into-view')
+import scrollIntoView from 'dom-scroll-into-view'
 import Autocomplete from '../Autocomplete'
-import { getStates, getCategorizedStates, matchStateToTermWithHeaders } from '../utils'
+import {
+  getStates,
+  getCategorizedStates,
+  matchStateToTermWithHeaders
+} from '../utils'
 
 function AutocompleteComponentJSX(extraProps) {
   return (
@@ -846,6 +852,16 @@ describe('Autocomplete isItemSelectable', () => {
     const menuDom = getByRole('listbox')
     const selectedItem = menuDom.querySelector('[data-is-highlighted="true"]')
     expect(selectedItem).toBeNull();
+  })
+
+  it('should call scrolling library when highlightedIndex changes', () => {
+    const { getByTestId, rerender } = renderElementAsDom({ open: true });
+    const input = getByTestId('inputField');
+    fireEvent.focus(input);
+    fireEvent.change(input, { event: { target: { value: 'Ar' }} });
+    rerender(AutocompleteComponentJSX({value: 'Ar'}));
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
   })
 })
 


### PR DESCRIPTION
Resolves the problem with scrolling, that has occurred, when you navigated using keyboard to the items that are non visible due to the height of the parent container. Now it will automatically scroll to make sure the currently highlighted item is visible.